### PR TITLE
Serve loading page during build and error page on failure

### DIFF
--- a/scripts/error-page.html
+++ b/scripts/error-page.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Application Unavailable</title>
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f5f5f5;
+      color: #333;
+    }
+    .container { text-align: center; }
+    .icon {
+      font-size: 48px;
+      margin-bottom: 24px;
+    }
+    h1 { font-size: 1.4rem; margin: 0 0 8px; }
+    p { font-size: 1rem; margin: 0; color: #666; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="icon">&#9888;</div>
+    <h1>Application is not available</h1>
+    <p>The application failed to start. Please check the logs for details.</p>
+  </div>
+</body>
+</html>

--- a/scripts/loading-page.html
+++ b/scripts/loading-page.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="refresh" content="10">
+  <title>Building...</title>
+  <style>
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f5f5f5;
+      color: #333;
+    }
+    .container { text-align: center; }
+    .spinner {
+      width: 48px;
+      height: 48px;
+      border: 4px solid #ddd;
+      border-top-color: #333;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+      margin: 0 auto 24px;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    p { font-size: 1.2rem; margin: 0; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="spinner"></div>
+    <p>Application is building&hellip;</p>
+  </div>
+</body>
+</html>

--- a/scripts/loading-server.js
+++ b/scripts/loading-server.js
@@ -1,0 +1,19 @@
+const http = require("http");
+const fs = require("fs");
+const path = require("path");
+
+const file = process.argv[2] || "loading-page.html";
+const html = fs.readFileSync(path.join(__dirname, file));
+const port = process.env.PORT || 8080;
+
+http
+  .createServer((_req, res) => {
+    res.writeHead(200, {
+      "Content-Type": "text/html",
+      "Cache-Control": "no-cache",
+    });
+    res.end(html);
+  })
+  .listen(port, () => {
+    console.log(`Loading page server listening on port ${port}`);
+  });


### PR DESCRIPTION
## Summary
- Serves a "building..." HTML page with a CSS spinner on port 8080 immediately when the container starts, so users don't see connection refused during clone/install/build
- If the build or application fails to start (non-zero exit), serves an "Application is not available" error page instead of letting the container exit
- Uses a minimal Node.js server (~15 lines) with no external dependencies; auto-reloads every 10 seconds during build via `<meta http-equiv="refresh">`

## Test plan
- [ ] `docker build -t web-runner:local .`
- [ ] `docker run --rm -e GITHUB_URL=https://github.com/<a-node-app> -p 8080:8080 web-runner:local` — open `http://localhost:8080` immediately, should see loading page with spinner
- [ ] Wait for build to complete — page auto-refreshes and shows the real app
- [ ] Test with an invalid repo URL — should show the error page after build failure
- [ ] Test with an app that crashes on start — should show the error page

🤖 Generated with [Claude Code](https://claude.com/claude-code)