### PR TITLE
feat: set APP_URL from OSC_HOSTNAME when available

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -65,6 +65,11 @@ if [[ ! -z "$OSC_ACCESS_TOKEN" ]] && [[ ! -z "$CONFIG_SVC" ]]; then
   eval `npx -y @osaas/cli@latest web config-to-env $CONFIG_SVC`
 fi
 
+if [[ -z "$APP_URL" ]] && [[ ! -z "$OSC_HOSTNAME" ]]; then
+  export APP_URL="https://$OSC_HOSTNAME"
+  echo "APP_URL set to $APP_URL"
+fi
+
 cd /usercontent/ && \
   npm install -g husky && \
   npm install --include=dev && \


### PR DESCRIPTION
## Summary
- Automatically sets `APP_URL=https://$OSC_HOSTNAME` when `OSC_HOSTNAME` is available and `APP_URL` is not already set
- Runs after config service env vars are loaded, so user-provided values take precedence
- Makes `APP_URL` available during both build and runtime

## Test plan
- [ ] Deploy with `OSC_HOSTNAME` set and verify `APP_URL` is derived correctly
- [ ] Deploy with `APP_URL` already set via config service and verify it is not overridden
- [ ] Deploy without `OSC_HOSTNAME` and verify no `APP_URL` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)