### PR TITLE
feat: add SUB_PATH support for monorepo deployments

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -79,7 +79,17 @@ if [[ -z "$AUTH_URL" ]] && [[ ! -z "$OSC_HOSTNAME" ]]; then
   echo "AUTH_URL set to $AUTH_URL"
 fi
 
-cd /usercontent/ && \
+WORK_DIR="/usercontent"
+if [[ ! -z "$SUB_PATH" ]]; then
+  WORK_DIR="/usercontent/$SUB_PATH"
+  if [[ ! -d "$WORK_DIR" ]]; then
+    echo "Error: SUB_PATH directory '$WORK_DIR' does not exist"
+    exit 1
+  fi
+  echo "Using SUB_PATH: $SUB_PATH (working directory: $WORK_DIR)"
+fi
+
+cd "$WORK_DIR" && \
   npm install -g husky && \
   npm install --include=dev && \
   npm run --if-present build && \


### PR DESCRIPTION
## Summary
- When `SUB_PATH` env var is set, the runner `cd`s into that subdirectory within `/usercontent/` before running `npm install` and build
- Validates the directory exists and exits with a clear error if not
- No behavior change when `SUB_PATH` is not set (backward compatible)

## Context
Closes #9

When deploying from a monorepo, users need to build and run from a subdirectory. This adds support for a `SUB_PATH` environment variable that changes the working directory before install/build/start.

After this is merged and the service is remade, the orchestrator schema should be updated to include `SubPath` so it becomes available as an env var. Related upstream PRs:
- https://github.com/Eyevinn/osaas-ai/pull/185
- https://github.com/Eyevinn/osaas-deploy-manager/pull/139

## Test plan
- [ ] Build Docker image locally and test with `SUB_PATH` unset (existing behavior)
- [ ] Test with `SUB_PATH` pointing to a valid subdirectory in a monorepo
- [ ] Test with `SUB_PATH` pointing to a non-existent directory (should fail with clear error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)