### PR TITLE
feat: log config variable count and document build-time availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Copy this file to the S3 bucket and then run container providing S3 URL and acce
 
 The web application is now available at http://localhost:8080
 
+### Environment Variables at Build Time
+
+Environment variables from the Application Config Service are loaded **before** `npm install` and `npm run build`. This means they are available at both build time and runtime.
+
+For frameworks like Next.js that require environment variables during the build step (e.g. `NEXT_PUBLIC_*`), set them in your Application Config Service parameter store and they will be embedded in the build output automatically.
+
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md)

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -65,6 +65,8 @@ if [[ ! -z "$OSC_ACCESS_TOKEN" ]] && [[ ! -z "$CONFIG_SVC" ]]; then
   config_env_output=$(npx -y @osaas/cli@latest web config-to-env "$CONFIG_SVC" 2>&1)
   if [ $? -eq 0 ]; then
     eval "$config_env_output"
+    var_count=$(echo "$config_env_output" | grep -c "^export " || true)
+    echo "[CONFIG] Loaded $var_count environment variable(s) — available for build and runtime"
   else
     echo "Warning: Failed to load config from application config service: $config_env_output"
   fi


### PR DESCRIPTION
## Summary
- After loading config service variables, log the count of loaded variables (without exposing values)
- Add README section documenting that config service env vars are available at build time, relevant for Next.js `NEXT_PUBLIC_*` variables

Closes #8

## Test plan
- [ ] Deploy with Application Config Service configured — verify log shows `[CONFIG] Loaded N environment variable(s) — available for build and runtime`
- [ ] Deploy without config service — verify no config log line appears
- [ ] Deploy Next.js app with `NEXT_PUBLIC_*` vars in config service — verify they are embedded in build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)