### PR TITLE
fix: chown /data/next-cache to node user to resolve EACCES on .next/cache at runtime

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -122,6 +122,9 @@ fi
 # Set up cache directories on persistent volume if available
 if [ -w "/data" ]; then
   mkdir -p /data/node_modules /data/next-cache
+  # Ensure the node user owns PVC cache directories to prevent EACCES at runtime
+  chown -R node:node /data/next-cache 2>/dev/null || true
+  chown -R node:node /data/node_modules 2>/dev/null || true
 
   # Set up .next/cache symlink (next build follows symlinks correctly)
   mkdir -p "$WORK_DIR/.next"


### PR DESCRIPTION
## Problem

Closes #14

When the container initialises, `docker-entrypoint.sh` runs as **root** and creates `/data/next-cache` via `mkdir -p`. The existing `chown node:node -R /usercontent/` call does **not** cover `/data/`, so `/data/next-cache` remains owned by root.

`WORK_DIR/.next/cache` is then symlinked to `/data/next-cache`. When the app process is later started via `runuser -u node`, the `node` user follows that symlink and tries to write cache files to the root-owned `/data/next-cache` directory — resulting in `EACCES: permission denied`.

## Fix

Immediately after `mkdir -p /data/node_modules /data/next-cache`, `chown -R node:node` both directories so the `node` process has write access through the symlink at runtime.

The `|| true` guard prevents a hard failure on PVCs that are mounted with restricted ownership where `chown` is not permitted (non-fatal degradation: cache simply won't be written).

## Changes

**`scripts/docker-entrypoint.sh`**
- Added `chown -R node:node /data/next-cache 2>/dev/null || true`
- Added `chown -R node:node /data/node_modules 2>/dev/null || true`

Both lines are placed immediately after the `mkdir` calls, inside the `if [ -w "/data" ]` guard, before the symlink is created.