### PR TITLE
fix: surface actionable token expiry warning in config load; log variable count on success

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -84,14 +84,19 @@ fi
 chown node:node -R /usercontent/
 
 if [[ ! -z "$OSC_ACCESS_TOKEN" ]] && [[ ! -z "$CONFIG_SVC" ]]; then
-  echo "Loading environment variables from application config service '$CONFIG_SVC'"
+  echo "[CONFIG] Loading environment variables from config service '$CONFIG_SVC'"
   config_env_output=$(npx -y @osaas/cli@latest web config-to-env "$CONFIG_SVC" 2>&1)
   if [ $? -eq 0 ]; then
     eval "$config_env_output"
     var_count=$(echo "$config_env_output" | grep -c "^export " || true)
     echo "[CONFIG] Loaded $var_count environment variable(s) — available for build and runtime"
   else
-    echo "Warning: Failed to load config from application config service: $config_env_output"
+    echo "[CONFIG] Warning: Failed to load config from application config service."
+    echo "[CONFIG] Output: $config_env_output"
+    if echo "$config_env_output" | grep -qi "expired\|unauthorized\|401"; then
+      echo "[CONFIG] Action required: Your OSC_ACCESS_TOKEN may have expired."
+      echo "[CONFIG] Use the 'refresh-app-config' MCP tool to issue a fresh token."
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Problem

References Eyevinn/osaas-ai#210

`OSC_ACCESS_TOKEN` has a limited lifetime. When it expires between container restarts, the `npx @osaas/cli web config-to-env` call fails with an "Authorization token expired" or 401 response. The previous code path issued only a single-line generic warning that concatenated the CLI output inline — making it hard to spot in logs — and gave no indication of what to do next. The app then started with zero environment variables from the config service.

## Fix

In the failure branch of the config loading block:

1. Separate the "failed" warning and the raw CLI output onto distinct lines so log parsers and humans can clearly see the CLI's message.
2. Detect token-expiry signals (`expired`, `unauthorized`, `401`) in the CLI output and emit an explicit, actionable instruction pointing to the `refresh-app-config` MCP tool.

The success path is unchanged in behaviour; the `echo` prefix is aligned to `[CONFIG]` for log consistency.

## Changes

**`scripts/docker-entrypoint.sh`** (config loading block, lines 86–101)

| Before | After |
|--------|-------|
| Generic single-line warning with output inlined | Warning and output on separate `[CONFIG]`-prefixed lines |
| No token-expiry detection | `grep -qi "expired\|unauthorized\|401"` triggers actionable message |
| `echo "Loading …"` (no prefix) | `echo "[CONFIG] Loading …"` (consistent prefix) |