### PR TITLE
fix: harden config loading to only eval valid export statements

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -86,13 +86,22 @@ chown node:node -R /usercontent/
 if [[ ! -z "$OSC_ACCESS_TOKEN" ]] && [[ ! -z "$CONFIG_SVC" ]]; then
   echo "[CONFIG] Loading environment variables from config service '$CONFIG_SVC'"
   config_env_output=$(npx -y @osaas/cli@latest web config-to-env "$CONFIG_SVC" 2>&1)
-  if [ $? -eq 0 ]; then
-    eval "$config_env_output"
-    var_count=$(echo "$config_env_output" | grep -c "^export " || true)
-    echo "[CONFIG] Loaded $var_count environment variable(s) — available for build and runtime"
+  config_exit=$?
+  if [ $config_exit -eq 0 ]; then
+    # Only eval lines that are valid shell export statements to prevent
+    # executing error messages or malformed output as shell commands
+    valid_exports=$(echo "$config_env_output" | grep "^export [A-Za-z_][A-Za-z0-9_]*=")
+    if [ -n "$valid_exports" ]; then
+      eval "$valid_exports"
+      var_count=$(echo "$valid_exports" | wc -l | tr -d ' ')
+      echo "[CONFIG] Loaded $var_count environment variable(s) — available for build and runtime"
+    else
+      echo "[CONFIG] WARNING: Config service returned success but no valid export statements."
+      echo "[CONFIG] Raw output: $config_env_output"
+    fi
   else
-    echo "[CONFIG] Warning: Failed to load config from application config service."
-    echo "[CONFIG] Output: $config_env_output"
+    echo "[CONFIG] ERROR: Failed to load config from '$CONFIG_SVC' (exit code $config_exit)."
+    echo "[CONFIG] Raw output: $config_env_output"
     if echo "$config_env_output" | grep -qi "expired\|unauthorized\|401"; then
       echo "[CONFIG] Action required: Your OSC_ACCESS_TOKEN may have expired."
       echo "[CONFIG] Use the 'refresh-app-config' MCP tool to issue a fresh token."


### PR DESCRIPTION
## Summary
- Filters `config-to-env` output through `grep "^export [A-Za-z_][A-Za-z0-9_]*="` before passing to `eval`, preventing error messages or malformed output from being executed as shell commands
- Adds `[CONFIG]` prefix and exit code to error logging
- Warns when CLI exits 0 but returns no valid export lines (e.g. empty parameter store or auth failure that doesn't set exit code)

## Problem
When `config-to-env` fails but exits 0 (or includes debug/error lines alongside exports), the raw output gets passed to `eval`. This produces cryptic errors like `Authorization: command not found` and can silently load 0 environment variables.

## Test plan
- [ ] Valid config service with exports → env vars load normally, count is correct
- [ ] CLI exits 0 but output contains non-export lines → only valid exports are eval'd, non-export lines ignored
- [ ] CLI exits non-zero → clear error message with exit code and raw output
- [ ] Empty parameter store (CLI exits 0, no exports) → warning about no valid export statements

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)