### PR TITLE
feat: exchange runner refresh token for fresh PAT at startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG NODE_IMAGE=node:20-alpine
 
 FROM ${NODE_IMAGE}
-RUN apk add --no-cache bash git runuser aws-cli
+RUN apk add --no-cache bash git runuser aws-cli curl jq
 ENV NODE_ENV=production
 WORKDIR /runner
 COPY ./scripts ./


### PR DESCRIPTION
## Summary
- Adds token refresh logic to the entrypoint script that runs before config loading
- If `OSC_ACCESS_TOKEN` is a runner refresh token, exchanges it for a fresh 1-hour PAT via `POST /runner-token/refresh`
- Adds `curl` and `jq` to the Dockerfile alpine dependencies

## Context
Closes #25

This is the final piece of the runner refresh token feature. The flow:
1. **Deploy-manager** (Eyevinn/osaas-deploy-manager#154) generates a 365-day runner refresh token and stores it as a K8s service secret
2. **Orchestrator** injects the secret into the pod as `OSC_ACCESS_TOKEN` via `{{secrets.*}}` reference
3. **This PR** — at startup, the entrypoint exchanges the refresh token for a fresh 1h PAT via the token service (Eyevinn/osaas-token-service#38)
4. The existing config-to-env block then uses the fresh PAT to load parameters

## Backward Compatibility
- **New apps** (with refresh token secret): curl succeeds → `OSC_ACCESS_TOKEN` gets a fresh PAT → config loads
- **Legacy apps** (with raw PAT): curl fails (400/401) → `OSC_ACCESS_TOKEN` retains original value → config loads as before (until PAT expires)

## Changes
- `Dockerfile` — add `curl` and `jq` to alpine apk install
- `scripts/docker-entrypoint.sh` — add refresh block before config loading, uses `OSC_ENV` env var (defaults to `prod`) for token service URL

## Test plan
- [ ] Build Docker image successfully
- [ ] New app with config service: verify `[CONFIG] Refreshed access token via runner refresh token` in logs
- [ ] Legacy app (raw PAT): verify no refresh message, config still loads
- [ ] Expired raw PAT: verify config loading fails gracefully with existing error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)