### PR TITLE
feat: support generic HTTPS git URLs with Gitea token auth fix

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -74,7 +74,7 @@ if [[ ! -z "$GIT_URL" ]]; then
     rm -rf /usercontent/* /usercontent/.[!.]*
     if [[ ! -z "$TOKEN" ]]; then
       echo "cloning https://***@${GIT_HOST}${GIT_PATH}"
-      git clone "https://${TOKEN}@${GIT_HOST}${GIT_PATH}" /usercontent/
+      git clone "https://token:${TOKEN}@${GIT_HOST}${GIT_PATH}" /usercontent/
     else
       echo "cloning https://${GIT_HOST}${GIT_PATH}"
       git clone "https://${GIT_HOST}${GIT_PATH}" /usercontent/


### PR DESCRIPTION
## Summary
- Supports cloning from any HTTPS git host (GitHub, Gitea, GitLab, Bitbucket, etc.) instead of only GitHub
- Fixes Gitea token authentication by using `token:TOKEN@host` format instead of `TOKEN@host` — Gitea requires the `token` username prefix for HTTP Basic Auth, while the old format caused `could not read Password` errors in non-interactive containers

## Test plan
- [ ] Deploy a My App from a GitHub repo with a PAT — verify clone succeeds
- [ ] Deploy a My App from a Gitea repo with an API token — verify clone succeeds (previously failed with "could not read Password")
- [ ] Deploy a My App from a public repo without any token — verify clone succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)