### PR TITLE
feat: write .commit-info.json after git clone for platform visibility

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -2,6 +2,23 @@
 
 STAGING_DIR="/usercontent"
 
+# Write commit metadata to a well-known file for platform visibility
+write_commit_info() {
+  local repo_dir="$1"
+  if [ -d "$repo_dir/.git" ]; then
+    git -C "$repo_dir" log -5 --format='{"sha":"%H","shortSha":"%h","message":"%s","author":"%an","date":"%aI"}' \
+      | jq -s '{
+          sha: .[0].sha,
+          shortSha: .[0].shortSha,
+          message: .[0].message,
+          author: .[0].author,
+          date: .[0].date,
+          recentCommits: .
+        }' > "$repo_dir/.commit-info.json" 2>/dev/null || true
+    echo "Commit info: $(jq -r '.shortSha + " - " + .message' "$repo_dir/.commit-info.json" 2>/dev/null || echo 'unavailable')"
+  fi
+}
+
 if [ -z "$SOURCE_URL" ] && [ -z "$GITHUB_URL" ]; then
   echo "SOURCE_URL or GITHUB_URL must be set. Exiting."
   exit 1
@@ -68,6 +85,7 @@ if [[ ! -z "$GIT_URL" ]]; then
     fi
     echo "cleaning untracked files (preserving node_modules and .next)"
     git -C /usercontent/ clean -fd --exclude=node_modules --exclude=.next
+    write_commit_info /usercontent
   else
     # Fresh clone — inject token into the URL if provided
     echo "ensure staging dir is empty"
@@ -83,6 +101,7 @@ if [[ ! -z "$GIT_URL" ]]; then
       echo "checking out branch: $branch"
       git -C /usercontent/ checkout "$branch"
     fi
+    write_commit_info /usercontent
   fi
 elif [[ ! -z "$S3_URL" ]]; then
   if [[ "$S3_URL" =~ ^.*\.zip$ ]]; then
@@ -239,6 +258,11 @@ if [ $BUILD_EXIT -eq 0 ]; then
   # Signal readiness for health checks
   mkdir -p "$WORK_DIR/public"
   echo "OK" > "$WORK_DIR/public/healthz"
+  # Make commit info available via static file serving (e.g. Next.js public dir)
+  if [ -f "/usercontent/.commit-info.json" ]; then
+    mkdir -p "$WORK_DIR/public/__osc"
+    cp /usercontent/.commit-info.json "$WORK_DIR/public/__osc/commit-info.json"
+  fi
 fi
 
 chown node:node -R /usercontent/

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -6,15 +6,30 @@ STAGING_DIR="/usercontent"
 write_commit_info() {
   local repo_dir="$1"
   if [ -d "$repo_dir/.git" ]; then
-    git -C "$repo_dir" log -5 --format='{"sha":"%H","shortSha":"%h","message":"%s","author":"%an","date":"%aI"}' \
-      | jq -s '{
-          sha: .[0].sha,
-          shortSha: .[0].shortSha,
-          message: .[0].message,
-          author: .[0].author,
-          date: .[0].date,
-          recentCommits: .
-        }' > "$repo_dir/.commit-info.json" 2>/dev/null || true
+    local sha shortSha msg author date recentCommits
+    sha=$(git -C "$repo_dir" rev-parse HEAD 2>/dev/null) || return 0
+    shortSha=$(git -C "$repo_dir" rev-parse --short HEAD 2>/dev/null) || return 0
+    msg=$(git -C "$repo_dir" log -1 --format='%s' 2>/dev/null) || return 0
+    author=$(git -C "$repo_dir" log -1 --format='%an' 2>/dev/null) || return 0
+    date=$(git -C "$repo_dir" log -1 --format='%aI' 2>/dev/null) || return 0
+    recentCommits=$(git -C "$repo_dir" log -5 --format='%H' 2>/dev/null | while read -r c_sha; do
+      jq -n \
+        --arg sha "$c_sha" \
+        --arg shortSha "$(git -C "$repo_dir" rev-parse --short "$c_sha" 2>/dev/null)" \
+        --arg message "$(git -C "$repo_dir" log -1 --format='%s' "$c_sha" 2>/dev/null)" \
+        --arg author "$(git -C "$repo_dir" log -1 --format='%an' "$c_sha" 2>/dev/null)" \
+        --arg date "$(git -C "$repo_dir" log -1 --format='%aI' "$c_sha" 2>/dev/null)" \
+        '{sha:$sha,shortSha:$shortSha,message:$message,author:$author,date:$date}'
+    done | jq -s '.' 2>/dev/null) || recentCommits='[]'
+    jq -n \
+      --arg sha "$sha" \
+      --arg shortSha "$shortSha" \
+      --arg message "$msg" \
+      --arg author "$author" \
+      --arg date "$date" \
+      --argjson recentCommits "$recentCommits" \
+      '{sha:$sha,shortSha:$shortSha,message:$message,author:$author,date:$date,recentCommits:$recentCommits}' \
+      > "$repo_dir/.commit-info.json" 2>/dev/null || true
     echo "Commit info: $(jq -r '.shortSha + " - " + .message' "$repo_dir/.commit-info.json" 2>/dev/null || echo 'unavailable')"
   fi
 }

--- a/scripts/loading-server.js
+++ b/scripts/loading-server.js
@@ -9,7 +9,18 @@ const port = process.env.PORT || 8080;
 
 http
   .createServer((req, res) => {
-    if (req.url === '/healthz') {
+    if (req.url === "/__osc/commit-info") {
+      try {
+        const info = fs.readFileSync("/usercontent/.commit-info.json", "utf8");
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(info);
+      } catch {
+        res.writeHead(404, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "no commit info available" }));
+      }
+      return;
+    }
+    if (req.url === "/healthz") {
       if (buildStatus === "failed") {
         res.writeHead(500, { "Content-Type": "application/json" });
         res.end(JSON.stringify({ status: "build-failed" }));


### PR DESCRIPTION
## Summary

After git clone (fresh) or git fetch+reset (PVC incremental), write `.commit-info.json` to `/usercontent` with:
- `sha` — full 40-char commit SHA
- `shortSha` — 7-char short SHA
- `message` — first line of commit message
- `author` — commit author name
- `date` — ISO 8601 date
- `recentCommits` — last 5 commits

The file is skipped for S3-sourced deploys (no `.git` directory).

Part of osaas-deploy-manager#321 (Show deployed commit SHA in My Apps).

## Test plan
- [ ] Deploy an app from GitHub, verify `/usercontent/.commit-info.json` is written after clone
- [ ] Rebuild app, verify file is updated with new SHA
- [ ] S3-sourced deploys proceed without error when no .git directory exists

🤖 Generated with [Claude Code](https://claude.ai/code)