### PR TITLE
Strip embedded credentials from GIT_HOST to prevent PAT leak

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -66,7 +66,11 @@ trap 'kill $LOADING_PID 2>/dev/null; wait $LOADING_PID 2>/dev/null' EXIT
 if [[ ! -z "$GIT_URL" ]]; then
   # Extract host and path from the URL dynamically (supports any HTTPS git host)
   GIT_HOST="${GIT_URL#*://}"   # strip scheme
-  GIT_HOST="${GIT_HOST%%/*}"   # keep only the hostname
+  GIT_HOST="${GIT_HOST%%/*}"   # keep only the hostname (may include user:pass@ if SOURCE_URL embeds credentials)
+  # Variant with any embedded credentials stripped — used for log lines and the
+  # persisted remote URL so that PATs never leak into pod logs or .git/config.
+  # When SOURCE_URL has no credentials, this is identical to GIT_HOST.
+  GIT_HOST_PUBLIC="${GIT_HOST##*@}"
   GIT_PATH="/${GIT_URL#*://*/}"
   [[ "/${GIT_URL}" == "${GIT_PATH}" ]] && GIT_PATH="/"
 
@@ -106,14 +110,19 @@ if [[ ! -z "$GIT_URL" ]]; then
     echo "ensure staging dir is empty"
     rm -rf /usercontent/* /usercontent/.[!.]*
     if [[ ! -z "$TOKEN" ]]; then
-      echo "cloning https://***@${GIT_HOST}${GIT_PATH}"
-      git clone "https://${TOKEN}@${GIT_HOST}${GIT_PATH}" /usercontent/
-    else
-      echo "cloning https://${GIT_HOST}${GIT_PATH}"
+      echo "cloning https://***@${GIT_HOST_PUBLIC}${GIT_PATH}"
+      git clone "https://${TOKEN}@${GIT_HOST_PUBLIC}${GIT_PATH}" /usercontent/
+    elif [[ "$GIT_HOST" != "$GIT_HOST_PUBLIC" ]]; then
+      # SOURCE_URL embeds credentials (e.g. Gitea: https://user:pass@host/...).
+      # Clone with them in place but keep them out of the log line.
+      echo "cloning https://***@${GIT_HOST_PUBLIC}${GIT_PATH}"
       git clone "https://${GIT_HOST}${GIT_PATH}" /usercontent/
+    else
+      echo "cloning https://${GIT_HOST_PUBLIC}${GIT_PATH}"
+      git clone "https://${GIT_HOST_PUBLIC}${GIT_PATH}" /usercontent/
     fi
     # Scrub PAT from origin remote — token must not persist to .git/config
-    git -C /usercontent/ remote set-url origin "https://${GIT_HOST}${GIT_PATH}"
+    git -C /usercontent/ remote set-url origin "https://${GIT_HOST_PUBLIC}${GIT_PATH}"
     if [[ ! -z "$branch" ]]; then
       echo "checking out branch: $branch"
       git -C /usercontent/ checkout "$branch"

--- a/tests/test-entrypoint-credential-scrub.sh
+++ b/tests/test-entrypoint-credential-scrub.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# tests/test-entrypoint-credential-scrub.sh
+#
+# Shell regression tests for the credential-scrub fix in scripts/docker-entrypoint.sh.
+#
+# Background:
+#   When SOURCE_URL embeds credentials (https://user:pass@host/path.git, the
+#   pattern used by Gitea-backed apps), the host extraction
+#       GIT_HOST="${GIT_URL#*://}"; GIT_HOST="${GIT_HOST%%/*}"
+#   yields "user:pass@host" — i.e. credentials remain in GIT_HOST.
+#
+#   The fresh-clone branch then echoed the credentialed URL into pod logs and,
+#   crucially, persisted the credentialed URL into .git/config because the
+#   "scrub" line
+#       git remote set-url origin "https://${GIT_HOST}${GIT_PATH}"
+#   reconstructed the same URL it was supposed to remove.
+#
+# Fix (this PR):
+#   Introduce GIT_HOST_PUBLIC="${GIT_HOST##*@}" — a sanitized variant used in
+#   log lines and the persisted remote URL. GIT_HOST keeps any embedded creds
+#   for the clone itself when no separate $TOKEN is provided. When SOURCE_URL
+#   has no credentials, GIT_HOST_PUBLIC == GIT_HOST and behavior is unchanged.
+#
+# These tests grep the entrypoint to assert the fix has not regressed.
+
+ENTRYPOINT="scripts/docker-entrypoint.sh"
+PASS=0
+FAIL=0
+
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+
+# ---------------------------------------------------------------------------
+# Test 1: GIT_HOST_PUBLIC is derived from GIT_HOST with embedded creds stripped
+# ---------------------------------------------------------------------------
+if grep -qE 'GIT_HOST_PUBLIC="\$\{GIT_HOST##\*@\}"' "$ENTRYPOINT"; then
+  pass "GIT_HOST_PUBLIC strips user:pass@ from GIT_HOST"
+else
+  fail "GIT_HOST_PUBLIC assignment is missing or does not strip embedded creds"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: persisted remote URL uses the scrubbed host
+# ---------------------------------------------------------------------------
+if grep -qF 'git -C /usercontent/ remote set-url origin "https://${GIT_HOST_PUBLIC}${GIT_PATH}"' "$ENTRYPOINT"; then
+  pass "remote set-url uses GIT_HOST_PUBLIC (credentials removed from .git/config)"
+else
+  fail "remote set-url still uses GIT_HOST — credentials would leak into .git/config"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: no surviving line that prints or persists the unscrubbed GIT_HOST
+#         in the fresh-clone branch
+#
+# The unscrubbed GIT_HOST is only allowed on the actual `git clone` line in
+# the elif branch (the SOURCE_URL-with-embedded-creds path), where we need
+# the credentials to authenticate. Every other reference must use
+# GIT_HOST_PUBLIC.
+# ---------------------------------------------------------------------------
+unsafe_echo=$(grep -nE 'echo "cloning https://\$\{GIT_HOST\}\$\{GIT_PATH\}"' "$ENTRYPOINT" || true)
+if [ -z "$unsafe_echo" ]; then
+  pass "no echo line prints the unscrubbed GIT_HOST"
+else
+  fail "echo line still prints unscrubbed GIT_HOST: $unsafe_echo"
+fi
+
+unsafe_persist=$(grep -nE 'remote set-url origin "https://\$\{GIT_HOST\}\$\{GIT_PATH\}"' "$ENTRYPOINT" || true)
+if [ -z "$unsafe_persist" ]; then
+  pass "no remote set-url persists the unscrubbed GIT_HOST"
+else
+  fail "remote set-url still persists unscrubbed GIT_HOST: $unsafe_persist"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: behavioral verification — run the relevant fragment in a sandbox
+#
+# Source the host-parsing logic with a Gitea-style SOURCE_URL and assert that
+# GIT_HOST_PUBLIC has no '@' while GIT_HOST does. This catches regressions
+# where the parameter expansion is changed in a way that defeats the strip.
+# ---------------------------------------------------------------------------
+sandbox=$(bash -c '
+  GIT_URL="https://oscadmin:abc123def@example.git.host/owner/repo.git"
+  GIT_HOST="${GIT_URL#*://}"
+  GIT_HOST="${GIT_HOST%%/*}"
+  GIT_HOST_PUBLIC="${GIT_HOST##*@}"
+  echo "GIT_HOST=$GIT_HOST"
+  echo "GIT_HOST_PUBLIC=$GIT_HOST_PUBLIC"
+')
+
+if echo "$sandbox" | grep -q '^GIT_HOST=oscadmin:abc123def@example.git.host$' && \
+   echo "$sandbox" | grep -q '^GIT_HOST_PUBLIC=example.git.host$'; then
+  pass "host-parsing on a Gitea-style URL strips creds in GIT_HOST_PUBLIC only"
+else
+  fail "host-parsing sandbox produced unexpected output: $sandbox"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: behavioral verification — credential-less URL is unchanged
+# ---------------------------------------------------------------------------
+sandbox_plain=$(bash -c '
+  GIT_URL="https://github.com/owner/repo.git"
+  GIT_HOST="${GIT_URL#*://}"
+  GIT_HOST="${GIT_HOST%%/*}"
+  GIT_HOST_PUBLIC="${GIT_HOST##*@}"
+  echo "GIT_HOST=$GIT_HOST"
+  echo "GIT_HOST_PUBLIC=$GIT_HOST_PUBLIC"
+')
+
+if echo "$sandbox_plain" | grep -q '^GIT_HOST=github.com$' && \
+   echo "$sandbox_plain" | grep -q '^GIT_HOST_PUBLIC=github.com$'; then
+  pass "host-parsing on a credential-less URL is a no-op (GIT_HOST_PUBLIC == GIT_HOST)"
+else
+  fail "credential-less host-parsing produced unexpected output: $sandbox_plain"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [ $FAIL -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Problem

For Gitea-hosted apps, `SOURCE_URL` embeds credentials directly as
`https://oscadmin:TOKEN@host/path`. After parsing, `GIT_HOST` still
contained the `user:pass@` prefix, leaking the PAT in two places:

1. **Stdout/Loki log leak** — the `"cloning https://..."` log line printed
   the unmasked credentialed URL including the PAT.
2. **`.git/config` persistence** — `git remote set-url origin
   "https://${GIT_HOST}${GIT_PATH}"` wrote the same credentialed URL into
   `/usercontent/.git/config`, persisting the PAT on disk in the running
   pod.

## Fix

Introduce `GIT_HOST_PUBLIC="${GIT_HOST##*@}"` immediately after the
`GIT_HOST="${GIT_HOST%%/*}"` path-trim step (line 69). This strips any
`user:pass@` prefix from `GIT_HOST` before it is echoed or used in
`git remote set-url`. A no-op when no `@` is present.

Use `GIT_HOST_PUBLIC` everywhere the URL is logged or persisted to disk:
- All three `echo "cloning ..."` branches
- `git remote set-url origin` after clone

The clone itself still uses the credentialed `GIT_HOST` path when
`SOURCE_URL` embeds credentials (the `GIT_HOST != GIT_HOST_PUBLIC` branch).
Behavior is unchanged for credential-less URLs and for the
`GIT_TOKEN`/`GITHUB_TOKEN` injection flow.

## Scope

GitHub-hosted apps are unaffected — they inject credentials via
`GIT_TOKEN`/`GITHUB_TOKEN` and do not embed them in `GIT_HOST`.

## Tests

Added `tests/test-entrypoint-credential-scrub.sh`:
- Grep-based regression tests that verify `GIT_HOST_PUBLIC` is used in
  every log line and in `git remote set-url`, and that bare `$GIT_HOST` is
  never echoed or used in `remote set-url`.
- Bash sandbox that exercises the `##*@` and `%%/*` expansions on both a
  Gitea-style URL (`https://oscadmin:TOKEN@gitea.host/owner/repo`) and a
  credential-less URL (`https://github.com/owner/repo`).

## Next steps (not in this PR)

After this PR merges, the OSC forks (`eyevinn-osaas/web-runner` and
`eyevinn-osaas-dev/web-runner`) must be synced from upstream and the
`web-runner` service remade so the fix reaches running pods.

🤖 Generated with [Claude Code](https://claude.ai/code)