### PR TITLE
fix: pass OSC_ENV to config-to-env CLI call (#38)

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -173,7 +173,7 @@ fi
 LOADED_CONFIG_EXPORTS=""
 if [[ ! -z "$OSC_ACCESS_TOKEN" ]] && [[ ! -z "$CONFIG_SVC" ]]; then
   echo "[CONFIG] Loading environment variables from config service '$CONFIG_SVC'"
-  config_env_output=$(npx -y @osaas/cli@latest web config-to-env "$CONFIG_SVC" 2>&1)
+  config_env_output=$(npx -y @osaas/cli@latest web config-to-env ${OSC_ENV:+--env "$OSC_ENV"} "$CONFIG_SVC" 2>&1)
   config_exit=$?
   if [ $config_exit -eq 0 ]; then
     # Only eval lines that are valid shell export statements to prevent


### PR DESCRIPTION
## Summary
- `config-to-env` was fetching config from the production parameter store on all environments
- Forwards `OSC_ENV` as `--env "$OSC_ENV"` when set, using the `${OSC_ENV:+--env "$OSC_ENV"}` idiom already used for the token refresh URL
- When `OSC_ENV` is unset, behaviour is unchanged (CLI defaults to prod)

Closes #38

## Manual follow-up
After this PR merges to upstream, the `eyevinn-osaas[-dev]/web-runner` fork must be synced and the service remade for the change to affect running OSC instances. Please handle fork sync + remake manually.

## Test plan
- [ ] Set `OSC_ENV=dev` in a web-runner container and verify config-to-env fetches from the dev parameter store
- [ ] Unset `OSC_ENV` and verify config-to-env still fetches from prod (unchanged default)

🤖 Generated with [Claude Code](https://claude.ai/code)