### PR TITLE
feat: support GIT_COMMIT_SHA env var to pin rebuild to exact commit (#42)

### DIFF
--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -96,7 +96,11 @@ if [[ ! -z "$GIT_URL" ]]; then
     git -C /usercontent/ fetch origin
     # Strip credentials again so PAT does not persist in .git/config
     git -C /usercontent/ remote set-url origin "https://${GIT_HOST_PUBLIC}${GIT_PATH}"
-    if [[ ! -z "$branch" ]]; then
+    if [ -n "${GIT_COMMIT_SHA:-}" ]; then
+      echo "checking out exact commit: $GIT_COMMIT_SHA"
+      git -C /usercontent/ fetch origin "$GIT_COMMIT_SHA" 2>/dev/null || true
+      git -C /usercontent/ checkout --detach "$GIT_COMMIT_SHA"
+    elif [[ ! -z "$branch" ]]; then
       echo "resetting to origin/$branch"
       git -C /usercontent/ checkout "$branch" 2>/dev/null || true
       git -C /usercontent/ reset --hard "origin/$branch"
@@ -130,7 +134,11 @@ if [[ ! -z "$GIT_URL" ]]; then
     fi
     # Scrub PAT from origin remote — token must not persist to .git/config
     git -C /usercontent/ remote set-url origin "https://${GIT_HOST_PUBLIC}${GIT_PATH}"
-    if [[ ! -z "$branch" ]]; then
+    if [ -n "${GIT_COMMIT_SHA:-}" ]; then
+      echo "checking out exact commit: $GIT_COMMIT_SHA"
+      git -C /usercontent/ fetch origin "$GIT_COMMIT_SHA" 2>/dev/null || true
+      git -C /usercontent/ checkout --detach "$GIT_COMMIT_SHA"
+    elif [[ ! -z "$branch" ]]; then
       echo "checking out branch: $branch"
       git -C /usercontent/ checkout "$branch"
     fi


### PR DESCRIPTION
## Summary

When `GIT_COMMIT_SHA` is set, `docker-entrypoint.sh` checks out that exact commit (detached HEAD) instead of resolving branch HEAD. Covers both the PVC-cached (existing-repo) path and the fresh-clone path. Preserves existing behavior when the env var is absent.

Fixes #42

🤖 Generated with [Claude Code](https://claude.ai/code)